### PR TITLE
fill miss node with ''

### DIFF
--- a/src/core/data.js
+++ b/src/core/data.js
@@ -172,7 +172,6 @@ define(function(require, exports, module) {
                     jsonMap[level] = jsonNode;
                 }
             }
-
             importChildren(node, children);
             minder.refresh();
         },

--- a/src/core/data.js
+++ b/src/core/data.js
@@ -172,6 +172,7 @@ define(function(require, exports, module) {
                     jsonMap[level] = jsonNode;
                 }
             }
+            
             importChildren(node, children);
             minder.refresh();
         },

--- a/src/core/data.js
+++ b/src/core/data.js
@@ -142,6 +142,17 @@ define(function(require, exports, module) {
                     importChildren(childNode, children[i].children);
                 }
             }
+            function fillEmptyNode(jsonMap, level) {
+                if (jsonMap[level]){
+                    return;
+                }
+                jsonMap[level] = {"children":[], "data":{"text":""}};
+                if (level < 1) {
+                    return;
+                }
+                fillEmptyNode(jsonMap, level - 1);
+                addChild(jsonMap[level - 1], jsonMap[level])
+            }
 
             while ((line = lines[i++]) !== undefined) {
                 line = line.replace(/&nbsp;/g, '');
@@ -155,7 +166,7 @@ define(function(require, exports, module) {
                     jsonMap[0] = children[children.length-1];
                 } else {
                     if (!jsonMap[level-1]) {
-                        throw new Error('Invalid local format');
+                        fillEmptyNode(jsonMap, level -1);
                     };
                     addChild(jsonMap[level-1], jsonNode);
                     jsonMap[level] = jsonNode;


### PR DESCRIPTION
using empty string to make jsonMap completed.
There is a scenario。 when i copy from xmind, content like the following
`

    node1
       node2
           node3
       node3-1
           node4
`
actually, node3 is node3\n node3-1 。but when i copy the xmind node , will get above text. 
then it cannot be imported . so i fill empty string so that make sure it can be imported ,which increasing user friendly